### PR TITLE
Require pp in example script to get OAuth token

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -38,6 +38,7 @@ If something in the API is confusing you, you can open an [issue](https://github
 ```ruby--oauth2
 #!/usr/bin/env ruby
 require 'oauth2' # gem 'oauth2'
+require 'pp'
 
 CONSUMER_KEY = <fill in your key>
 CONSUMER_SECRET = <fill in your secret>


### PR DESCRIPTION
The script failed when I tried to run it because `pp` was not available. AFAIK this is always needed, but even if it isn't for some ruby version I guess it won't hurt. 