### PR TITLE
Fix typos in create_expense params

### DIFF
--- a/source/includes/_expenses.md
+++ b/source/includes/_expenses.md
@@ -122,15 +122,15 @@ Parameter | Type | Description
 --------- | ---- | -----------
 group_id              | Integer | The group to put this expense in.
 split_equally         | Boolean | Set this to `true` if using it
-user\__0\__id         | Integer | The user id of a friend for this share
-user\__0\__paid_share | String  | Decimal amount as a string with 2 decimal places. The amount this user paid for the expense
-user\__0\__owed_share | String  | Decimal amount as a string with 2 decimal places. The amount this user owes on the expense
-user\__1\__first_name | String  |
-user\__1\__last_name  | String  |
-user\__1\__email      | String  | Valid email address for this user
-user\__1\__paid_share | String  | Decimal amount as a string with 2 decimal places. The amount this user paid for the expense
-user\__1\__owed_share | String  | Decimal amount as a string with 2 decimal places. The amount this user owes on the expense
-user\__*\__key_value  | String  | Add additional user shares with indexes 2,3,4,5,...
+users\__0\__id         | Integer | The user id of a friend for this share
+users\__0\__paid_share | String  | Decimal amount as a string with 2 decimal places. The amount this user paid for the expense
+users\__0\__owed_share | String  | Decimal amount as a string with 2 decimal places. The amount this user owes on the expense
+users\__1\__first_name | String  |
+users\__1\__last_name  | String  |
+users\__1\__email      | String  | Valid email address for this user
+users\__1\__paid_share | String  | Decimal amount as a string with 2 decimal places. The amount this user paid for the expense
+users\__1\__owed_share | String  | Decimal amount as a string with 2 decimal places. The amount this user owes on the expense
+users\__*\__key_value  | String  | Add additional user shares with indexes 2,3,4,5,...
 
 #### Optional parameters
 


### PR DESCRIPTION
Specifically, `user__*` should be `users__*`.