### PR TITLE
add Pizzly to list of JavaScript SDKs

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -35,6 +35,7 @@ The development community has built a number of unofficial, third-party SDKs for
 
 - Javascript
   - [https://github.com/keriwarr/splitwise](https://github.com/keriwarr/splitwise)
+  - [https://github.com/Bearer/Pizzly](https://github.com/Bearer/Pizzly)
 - Ruby
   - [https://github.com/divyum/splitwise-ruby](https://github.com/divyum/splitwise-ruby)
 - Python


### PR DESCRIPTION
## Summary
- Added [https://github.com/Bearer/Pizzly](https://github.com/Bearer/Pizzly) to the JavaScript SDKs list. 

## Background
- I added Splitwise as a [released integration in Pizzly](https://github.com/Bearer/Pizzly/pull/188) so I could use it in basic Vue.js Front End to automate some of the settings I always use with my partner for our budgeting. 