### PR TITLE
Update user endpoint response shapes

### DIFF
--- a/paths/get_user.yaml
+++ b/paths/get_user.yaml
@@ -15,7 +15,10 @@ get:
       content:
         application/json:
           schema:
-            "$ref": "../schemas/user.yaml"
+            type: object
+            properties:
+              user:
+                "$ref": "../schemas/user.yaml"
     '401':
       "$ref": "../responses/unauthorized.yaml"
     '403':

--- a/schemas/user.yaml
+++ b/schemas/user.yaml
@@ -23,3 +23,6 @@ properties:
         type: string
       large:
         type: string
+  custom_picture:
+    type: bool
+    example: false


### PR DESCRIPTION
Update the shape of the `/get_user/{id}` endpoint to match actual response (missing a parent "user" object wrapping all the details, as in the get_current_user endpoint).

Docs shape:
```
{
  "id": 0,
  "first_name": "Ada",
  "last_name": "Lovelace",
  "email": "ada@example.com",
  "registration_status": "confirmed",
  "picture": {
    "small": "string",
    "medium": "string",
    "large": "string"
  }
}
```
Actual response:
```
{
    "user": {
        "id": 49783008,
        "first_name": "Angus",
        "last_name": null,
        "picture": {
            "small": "https://s3.amazonaws.com/splitwise/uploads/user/default_avatars/avatar-teal45-50px.png",
            "medium": "https://s3.amazonaws.com/splitwise/uploads/user/default_avatars/avatar-teal45-100px.png",
            "large": "https://s3.amazonaws.com/splitwise/uploads/user/default_avatars/avatar-teal45-200px.png"
        },
        "custom_picture": false,
        "email": "xxxxxx",
        "registration_status": "confirmed"
    }
}
```

Additionally added the custom_picture fields to the documentation for `/get_current_user` and `get_user/{id}`