### PR TITLE
Fix user.yaml custom_picture basic type: 'boolean' not 'bool'

### DIFF
--- a/schemas/user.yaml
+++ b/schemas/user.yaml
@@ -24,5 +24,5 @@ properties:
       large:
         type: string
   custom_picture:
-    type: bool
+    type: boolean
     example: false


### PR DESCRIPTION
The correct spelling is 'boolean'. Reference https://swagger.io/docs/specification/data-models/data-types/

Found because my client of choice failed to open current file due to this typo.